### PR TITLE
chore: enable graphiql

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,4 +59,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.assets.precompile += ['graphiql/rails/application.js', 'graphiql/rails/application.css']
 end


### PR DESCRIPTION
#4 

I was seeing the following error message when I tried to open the `/graphiql` endpoint after installing the GraphQL-Ruby gem:

```
Sprockets::Rails::Helper::AssetNotPrecompiled in GraphiQL::Rails::Editors#show
```

After reading [this](https://github.com/rmosolgo/graphiql-rails/issues/75) thread, I included assets for GraphiQL in the configuration for the development environment (since GraphiQL will only be used during development). This allowed me to access the GraphiQL interface from the `/graphiql` endpoint and query the test field:

```graphql
query {
  testField
}
```